### PR TITLE
fix(forge/neoforge): make the P2P share code clickable and narrated

### DIFF
--- a/forge/src/main/java/org/developerkubilay/safra/mixin/client/IntegratedServerMixin.java
+++ b/forge/src/main/java/org/developerkubilay/safra/mixin/client/IntegratedServerMixin.java
@@ -3,7 +3,10 @@ package org.developerkubilay.safra.mixin.client;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.world.level.GameType;
 import org.developerkubilay.safra.client.config.RemoteRendezvousConfigUpdater;
 import org.developerkubilay.safra.client.p2p.ForgeLanGameRules;
@@ -84,7 +87,13 @@ abstract class IntegratedServerMixin {
         SAFRA_LOGGER.info("Safra P2P server opened on local TCP port {}. Share code: {}", tcpPort, shareCodeText);
         client.keyboardHandler.setClipboard(shareCodeText);
 
-        Component shareText = Component.literal(shareCodeText).withStyle(ChatFormatting.AQUA, ChatFormatting.UNDERLINE);
+        Component shareText = Component.literal(shareCodeText)
+            .setStyle(Style.EMPTY
+                .withColor(ChatFormatting.AQUA)
+                .withUnderlined(true)
+                .withInsertion(shareCodeText)
+                .withClickEvent(new ClickEvent.CopyToClipboard(shareCodeText))
+                .withHoverEvent(new HoverEvent.ShowText(Component.translatable("safra.p2p.copy_hint"))));
         client.gui.getChat().addClientSystemMessage(Component.translatable("safra.p2p.host.started", shareText));
         if (!shareCode.isRendezvous()) {
             client.gui.getChat().addClientSystemMessage(
@@ -103,6 +112,7 @@ abstract class IntegratedServerMixin {
 
         client.gui.getChat().addClientSystemMessage(Component.translatable("safra.p2p.host.copied"));
         client.gui.getChat().addClientSystemMessage(Component.translatable("safra.p2p.host.instructions"));
+        client.getNarrator().saySystemQueued(Component.translatable("safra.p2p.host.narration", shareText));
         safra$startBedrockRelay(client);
     }
 

--- a/neoforge/src/main/java/org/developerkubilay/safra/mixin/client/IntegratedServerMixin.java
+++ b/neoforge/src/main/java/org/developerkubilay/safra/mixin/client/IntegratedServerMixin.java
@@ -3,7 +3,10 @@ package org.developerkubilay.safra.mixin.client;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.Style;
 import net.minecraft.world.level.GameType;
 import org.developerkubilay.safra.client.config.RemoteRendezvousConfigUpdater;
 import org.developerkubilay.safra.client.p2p.NeoForgeLanGameRules;
@@ -84,7 +87,13 @@ abstract class IntegratedServerMixin {
         SAFRA_LOGGER.info("Safra P2P server opened on local TCP port {}. Share code: {}", tcpPort, shareCodeText);
         client.keyboardHandler.setClipboard(shareCodeText);
 
-        Component shareText = Component.literal(shareCodeText).withStyle(ChatFormatting.AQUA, ChatFormatting.UNDERLINE);
+        Component shareText = Component.literal(shareCodeText)
+            .setStyle(Style.EMPTY
+                .withColor(ChatFormatting.AQUA)
+                .withUnderlined(true)
+                .withInsertion(shareCodeText)
+                .withClickEvent(new ClickEvent.CopyToClipboard(shareCodeText))
+                .withHoverEvent(new HoverEvent.ShowText(Component.translatable("safra.p2p.copy_hint"))));
         client.gui.getChat().addClientSystemMessage(Component.translatable("safra.p2p.host.started", shareText));
         if (!shareCode.isRendezvous()) {
             client.gui.getChat().addClientSystemMessage(
@@ -103,6 +112,7 @@ abstract class IntegratedServerMixin {
 
         client.gui.getChat().addClientSystemMessage(Component.translatable("safra.p2p.host.copied"));
         client.gui.getChat().addClientSystemMessage(Component.translatable("safra.p2p.host.instructions"));
+        client.getNarrator().saySystemQueued(Component.translatable("safra.p2p.host.narration", shareText));
         safra$startBedrockRelay(client);
     }
 


### PR DESCRIPTION
### Problem

When a world is opened with P2P, the share code is posted to chat and immediately followed by `safra.p2p.host.copied`:

> Share code copied to clipboard. **Click the code in chat to copy it again.**

On Fabric that is true. On Forge and NeoForge it is not: `IntegratedServerMixin#safra$publishShareCode` builds the component as

```java
Component shareText = Component.literal(shareCodeText).withStyle(ChatFormatting.AQUA, ChatFormatting.UNDERLINE);
```

so the code is only aqua + underlined — clicking it does nothing, hovering shows nothing, and the code is never narrated. The message tells the user to do something the client does not support, which matters once the code has scrolled out of the clipboard's way (rejoining friends, re-sharing after a `stopHosting`).

Two consequences of the drift:

- `safra.p2p.copy_hint` and `safra.p2p.host.narration` are used only by the Fabric mixin, even though both are already translated in all 12 language files.
- Screen-reader users on Forge/NeoForge never hear the share code.

### Fix

Mirror the Fabric implementation (`OpenToLanScreenMixin#safra$publishShareCode`) in `forge` and `neoforge`:

- build the share code with `Style.EMPTY` carrying the aqua colour, underline, `withInsertion(...)`, `ClickEvent.CopyToClipboard` and a `HoverEvent.ShowText(safra.p2p.copy_hint)`;
- queue `safra.p2p.host.narration` after the instructions line.

The code is copied verbatim from the Fabric mixin, so all three loaders now behave identically and no new translation keys are needed.

### Notes

- No behaviour change on Fabric; no new strings; nothing added to the wire protocol.
- Verified with `./gradlew :forge:compileJava :neoforge:compileJava` — `BUILD SUCCESSFUL`.
