### PR TITLE
fix(fabric): keep the dedicated server share code stable across restarts

### DIFF
--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -1,5 +1,10 @@
 package org.developerkubilay.safra.server;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import net.minecraft.server.MinecraftServer;
 import org.developerkubilay.safra.p2p.CachedRendezvousConfigLoader;
 import org.developerkubilay.safra.p2p.ConsoleShareCodePrinter;
@@ -11,16 +16,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public final class DedicatedP2pServerManager {
     private static final Logger LOGGER = LoggerFactory.getLogger("Safra P2P");
-    private static final Pattern FIXED_CODE_ENABLED_PATTERN = Pattern.compile("\"openToLanFixedCodeEnabled\"\\s*:\\s*(true|false)");
-    private static final Pattern FIXED_CODE_PATTERN = Pattern.compile("\"openToLanFixedCode\"\\s*:\\s*\"([^\"]*)\"");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     private static P2pHostService hostService;
 
     private DedicatedP2pServerManager() {
@@ -36,7 +40,7 @@ public final class DedicatedP2pServerManager {
         RemoteRendezvousBootstrap.initializeDedicated();
 
         int tcpPort = server.getPort();
-        String fixedCode = loadFixedCode(Paths.get("config", "safra-client.json"));
+        String fixedCode = loadOrCreateFixedCode(Paths.get("config", "safra-client.json"));
         try {
             P2pHostSupport.HostStartResult hostStartResult = P2pHostSupport.startDedicatedHost(tcpPort, server.getLocalIp(), fixedCode, LOGGER);
             hostService = hostStartResult.service();
@@ -74,27 +78,53 @@ public final class DedicatedP2pServerManager {
         hostService = null;
     }
 
-    private static String loadFixedCode(Path configPath) {
+    private static String loadOrCreateFixedCode(Path configPath) {
         try {
-            if (!Files.exists(configPath)) {
+            JsonObject config = readConfig(configPath);
+            JsonElement enabled = config.get("openToLanFixedCodeEnabled");
+            if (enabled != null && enabled.isJsonPrimitive() && !enabled.getAsBoolean()) {
                 return null;
             }
 
-            String json = Files.readString(configPath);
-            Matcher enabledMatcher = FIXED_CODE_ENABLED_PATTERN.matcher(json);
-            if (!enabledMatcher.find() || !Boolean.parseBoolean(enabledMatcher.group(1))) {
-                return null;
+            JsonElement storedCode = config.get("openToLanFixedCode");
+            String fixedCode = storedCode != null && storedCode.isJsonPrimitive()
+                ? P2pShareCode.normalizeRendezvousCode(storedCode.getAsString())
+                : null;
+            if (fixedCode != null) {
+                return fixedCode;
             }
 
-            Matcher codeMatcher = FIXED_CODE_PATTERN.matcher(json);
-            if (!codeMatcher.find()) {
-                return null;
-            }
-
-            return P2pShareCode.normalizeRendezvousCode(codeMatcher.group(1));
-        } catch (IOException exception) {
+            fixedCode = P2pShareCode.createRendezvousCode(P2pShareCode.FIXED_RENDEZVOUS_CODE_LENGTH);
+            config.addProperty("openToLanFixedCodeEnabled", true);
+            config.addProperty("openToLanFixedCode", fixedCode);
+            writeConfig(configPath, config);
+            LOGGER.info("Safra dedicated share code created and stored in {}", configPath);
+            return fixedCode;
+        } catch (IOException | RuntimeException exception) {
             LOGGER.warn("Safra dedicated fixed code could not be read from {}", configPath, exception);
             return null;
+        }
+    }
+
+    private static JsonObject readConfig(Path configPath) throws IOException {
+        if (!Files.isRegularFile(configPath)) {
+            return new JsonObject();
+        }
+
+        try (Reader reader = Files.newBufferedReader(configPath)) {
+            JsonElement parsed = JsonParser.parseReader(reader);
+            return parsed != null && parsed.isJsonObject() ? parsed.getAsJsonObject() : new JsonObject();
+        }
+    }
+
+    private static void writeConfig(Path configPath, JsonObject config) throws IOException {
+        Path parent = configPath.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
+        }
+
+        try (Writer writer = Files.newBufferedWriter(configPath)) {
+            GSON.toJson(config, writer);
         }
     }
 }

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import net.minecraft.server.MinecraftServer;
 import org.developerkubilay.safra.p2p.CachedRendezvousConfigLoader;
 import org.developerkubilay.safra.p2p.ConsoleShareCodePrinter;
@@ -113,7 +114,11 @@ public final class DedicatedP2pServerManager {
 
         try (Reader reader = Files.newBufferedReader(configPath)) {
             JsonElement parsed = JsonParser.parseReader(reader);
-            return parsed != null && parsed.isJsonObject() ? parsed.getAsJsonObject() : new JsonObject();
+            if (parsed == null || !parsed.isJsonObject()) {
+                throw new JsonSyntaxException("Safra config root must be a JSON object");
+            }
+
+            return parsed.getAsJsonObject();
         }
     }
 

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -3,7 +3,9 @@ package org.developerkubilay.safra.server;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonIOException;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import net.minecraft.server.MinecraftServer;
@@ -19,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -84,8 +87,10 @@ public final class DedicatedP2pServerManager {
     }
 
     private static String loadOrCreateFixedCode(Path configPath) {
+        JsonObject config;
+        String fixedCode;
         try {
-            JsonObject config = readConfig(configPath);
+            config = readConfig(configPath);
             JsonElement enabled = config.get("openToLanFixedCodeEnabled");
             if (enabled != null) {
                 if (!enabled.isJsonPrimitive() || !enabled.getAsJsonPrimitive().isBoolean()) {
@@ -101,23 +106,29 @@ public final class DedicatedP2pServerManager {
                 throw new JsonSyntaxException("openToLanFixedCode must be a string");
             }
 
-            String fixedCode = storedCode == null
+            fixedCode = storedCode == null
                 ? null
                 : P2pShareCode.normalizeRendezvousCode(storedCode.getAsString());
             if (fixedCode != null) {
                 return fixedCode;
             }
-
-            fixedCode = P2pShareCode.createRendezvousCode(P2pShareCode.FIXED_RENDEZVOUS_CODE_LENGTH);
-            config.addProperty("openToLanFixedCodeEnabled", true);
-            config.addProperty("openToLanFixedCode", fixedCode);
-            writeConfig(configPath, config);
-            LOGGER.info("Safra dedicated share code created and stored in {}", configPath);
-            return fixedCode;
-        } catch (IOException | RuntimeException exception) {
+        } catch (IOException | JsonParseException exception) {
             LOGGER.warn("Safra dedicated fixed code could not be read from {}", configPath, exception);
             return null;
         }
+
+        fixedCode = P2pShareCode.createRendezvousCode(P2pShareCode.FIXED_RENDEZVOUS_CODE_LENGTH);
+        config.addProperty("openToLanFixedCodeEnabled", true);
+        config.addProperty("openToLanFixedCode", fixedCode);
+        try {
+            writeConfig(configPath, config);
+        } catch (IOException | JsonIOException exception) {
+            LOGGER.warn("Safra dedicated fixed code could not be stored in {}", configPath, exception);
+            return null;
+        }
+
+        LOGGER.info("Safra dedicated share code created and stored in {}", configPath);
+        return fixedCode;
     }
 
     private static JsonObject readConfig(Path configPath) throws IOException {
@@ -125,7 +136,7 @@ public final class DedicatedP2pServerManager {
             return new JsonObject();
         }
 
-        try (Reader reader = Files.newBufferedReader(configPath)) {
+        try (Reader reader = Files.newBufferedReader(configPath, StandardCharsets.UTF_8)) {
             JsonElement parsed = JsonParser.parseReader(reader);
             if (parsed == null || !parsed.isJsonObject()) {
                 throw new JsonSyntaxException("Safra config root must be a JSON object");
@@ -142,7 +153,7 @@ public final class DedicatedP2pServerManager {
 
         Path temporaryPath = Files.createTempFile(parent, "safra-client", ".json.tmp");
         try {
-            try (Writer writer = Files.newBufferedWriter(temporaryPath)) {
+            try (Writer writer = Files.newBufferedWriter(temporaryPath, StandardCharsets.UTF_8)) {
                 GSON.toJson(config, writer);
             }
 

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -19,9 +19,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 public final class DedicatedP2pServerManager {
     private static final Logger LOGGER = LoggerFactory.getLogger("Safra P2P");
@@ -132,13 +134,28 @@ public final class DedicatedP2pServerManager {
     }
 
     private static void writeConfig(Path configPath, JsonObject config) throws IOException {
-        Path parent = configPath.toAbsolutePath().getParent();
-        if (parent != null) {
-            Files.createDirectories(parent);
-        }
+        Path target = configPath.toAbsolutePath();
+        Path parent = target.getParent();
+        Files.createDirectories(parent);
 
-        try (Writer writer = Files.newBufferedWriter(configPath)) {
-            GSON.toJson(config, writer);
+        Path temporaryPath = Files.createTempFile(parent, "safra-client", ".json.tmp");
+        try {
+            try (Writer writer = Files.newBufferedWriter(temporaryPath)) {
+                GSON.toJson(config, writer);
+            }
+
+            try {
+                Files.move(temporaryPath, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException exception) {
+                Files.move(temporaryPath, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException | RuntimeException exception) {
+            try {
+                Files.deleteIfExists(temporaryPath);
+            } catch (IOException suppressed) {
+                exception.addSuppressed(suppressed);
+            }
+            throw exception;
         }
     }
 }

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -136,7 +136,7 @@ public final class DedicatedP2pServerManager {
     }
 
     private static void writeConfig(Path configPath, JsonObject config) throws IOException {
-        Path target = configPath.toAbsolutePath();
+        Path target = resolveTarget(configPath.toAbsolutePath());
         Path parent = target.getParent();
         Files.createDirectories(parent);
 
@@ -160,6 +160,27 @@ public final class DedicatedP2pServerManager {
                 exception.addSuppressed(suppressed);
             }
             throw exception;
+        }
+    }
+
+    /**
+     * Resolves the config a symlink points at, so the write lands where the operator aimed it.
+     *
+     * <p>Replacing a path atomically means replacing whatever sits at that path, and if that is a
+     * symlink the move destroys the link and leaves a regular file in its place. Someone who pointed
+     * config/safra-client.json at a shared or version-controlled location would find the link gone
+     * and their real config untouched the first time a share code was stored. Following the link
+     * instead keeps that setup working, and it also keeps the temporary file on the same filesystem
+     * as the file it replaces, which is what lets the move stay atomic.
+     *
+     * <p>A path that does not exist yet resolves to itself: there is no link to follow, and creating
+     * the file where it was asked for is the only sensible reading.
+     */
+    private static Path resolveTarget(Path configPath) {
+        try {
+            return configPath.toRealPath();
+        } catch (IOException exception) {
+            return configPath;
         }
     }
 

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -83,14 +83,23 @@ public final class DedicatedP2pServerManager {
         try {
             JsonObject config = readConfig(configPath);
             JsonElement enabled = config.get("openToLanFixedCodeEnabled");
-            if (enabled != null && enabled.isJsonPrimitive() && !enabled.getAsBoolean()) {
-                return null;
+            if (enabled != null) {
+                if (!enabled.isJsonPrimitive() || !enabled.getAsJsonPrimitive().isBoolean()) {
+                    throw new JsonSyntaxException("openToLanFixedCodeEnabled must be a boolean");
+                }
+                if (!enabled.getAsBoolean()) {
+                    return null;
+                }
             }
 
             JsonElement storedCode = config.get("openToLanFixedCode");
-            String fixedCode = storedCode != null && storedCode.isJsonPrimitive()
-                ? P2pShareCode.normalizeRendezvousCode(storedCode.getAsString())
-                : null;
+            if (storedCode != null && (!storedCode.isJsonPrimitive() || !storedCode.getAsJsonPrimitive().isString())) {
+                throw new JsonSyntaxException("openToLanFixedCode must be a string");
+            }
+
+            String fixedCode = storedCode == null
+                ? null
+                : P2pShareCode.normalizeRendezvousCode(storedCode.getAsString());
             if (fixedCode != null) {
                 return fixedCode;
             }

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -24,6 +24,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 
 public final class DedicatedP2pServerManager {
     private static final Logger LOGGER = LoggerFactory.getLogger("Safra P2P");
@@ -144,6 +146,8 @@ public final class DedicatedP2pServerManager {
                 GSON.toJson(config, writer);
             }
 
+            copyPermissions(target, temporaryPath);
+
             try {
                 Files.move(temporaryPath, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
             } catch (AtomicMoveNotSupportedException exception) {
@@ -156,6 +160,32 @@ public final class DedicatedP2pServerManager {
                 exception.addSuppressed(suppressed);
             }
             throw exception;
+        }
+    }
+
+    /**
+     * Carries the config's current permissions onto the replacement.
+     *
+     * <p>{@link Files#createTempFile} creates an owner-only file, and replacing the config with it
+     * hands those permissions to the config too. An operator who had deliberately widened the file -
+     * a shared admin group on a dedicated box is the usual reason - would silently lose that on the
+     * first write, which is not something a share-code update should decide. A config that does not
+     * exist yet keeps the restrictive default: nobody has expressed an opinion about it, and that is
+     * the safer of the two ways to guess.
+     */
+    private static void copyPermissions(Path target, Path temporaryPath) {
+        if (!Files.isRegularFile(target)) {
+            return;
+        }
+
+        try {
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(target);
+            Files.setPosixFilePermissions(temporaryPath, permissions);
+        } catch (UnsupportedOperationException exception) {
+            // Windows and any other non-POSIX filesystem: there is nothing to carry, and the
+            // replacement inherits the directory's ACL the same way the original did.
+        } catch (IOException | RuntimeException exception) {
+            LOGGER.warn("Safra could not carry the permissions of {} onto its replacement", target, exception);
         }
     }
 }

--- a/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
+++ b/fabric/src/main/java/org/developerkubilay/safra/server/DedicatedP2pServerManager.java
@@ -173,14 +173,29 @@ public final class DedicatedP2pServerManager {
      * instead keeps that setup working, and it also keeps the temporary file on the same filesystem
      * as the file it replaces, which is what lets the move stay atomic.
      *
-     * <p>A path that does not exist yet resolves to itself: there is no link to follow, and creating
-     * the file where it was asked for is the only sensible reading.
+     * <p>Links are followed explicitly before {@link Path#toRealPath()} is used. That matters for a
+     * dangling/new symlink: {@code toRealPath()} cannot resolve it because the destination does not
+     * exist yet, but {@link Files#readSymbolicLink(Path)} can still tell us where the operator wants
+     * the config written. A short depth limit also makes a symlink cycle fail safely instead of ever
+     * falling back to replacing one of the links.
      */
-    private static Path resolveTarget(Path configPath) {
+    private static Path resolveTarget(Path configPath) throws IOException {
+        Path target = configPath.toAbsolutePath().normalize();
+        for (int depth = 0; depth < 40 && Files.isSymbolicLink(target); depth++) {
+            Path linkTarget = Files.readSymbolicLink(target);
+            target = linkTarget.isAbsolute()
+                ? linkTarget.normalize()
+                : target.getParent().resolve(linkTarget).normalize();
+        }
+
+        if (Files.isSymbolicLink(target)) {
+            throw new IOException("Too many symbolic links while resolving Safra config: " + configPath);
+        }
+
         try {
-            return configPath.toRealPath();
+            return target.toRealPath();
         } catch (IOException exception) {
-            return configPath;
+            return target;
         }
     }
 


### PR DESCRIPTION
### Problem

A dedicated server is meant to hand out the same share code on every boot — `DedicatedP2pServerManager` reads `openToLanFixedCode` from `config/safra-client.json` and passes it to `P2pHostSupport.startDedicatedHost`.

On Fabric that never happens. The file is only ever written by `SafraClientConfig`, which lives in `fabric/src/client` and so does not exist on a dedicated server. `loadFixedCode` therefore hits

```java
if (!Files.exists(configPath)) {
    return null;
}
```

on a fresh server, returns `null`, and the host falls back to a freshly generated random code. Every restart produces a new code, and the admin has to redistribute it to every player.

Forge and NeoForge do not have this problem — the same method there calls `SafraClientConfig.get().ensureOpenToLanFixedCode()`, which generates a 16-character code and persists it on first boot.

### Fix

Give Fabric the same behaviour without dragging the client-only config class into the server source set:

- parse the config with Gson instead of the two regexes;
- when the fixed code is enabled but absent or invalid, generate one via `P2pShareCode.createRendezvousCode(FIXED_RENDEZVOUS_CODE_LENGTH)` — the same call `ensureOpenToLanFixedCode()` makes — and write it back.

Behaviour that is deliberately preserved:

- an existing config is round-tripped through `JsonObject`, so unrelated keys (`rendezvousUrl`, `openToLanGameRules`, …) survive untouched;
- `"openToLanFixedCodeEnabled": false` still yields a per-session random code, matching `config.isOpenToLanFixedCodeEnabled() ? ... : null` on Forge;
- a file that cannot be understood is logged and ignored rather than rewritten, and never partially rewritten. That covers malformed JSON, a root that parses but is not an object (`[]`, `null`, a bare scalar, an empty file), and a field carrying the wrong type (`"openToLanFixedCodeEnabled": []`, `"openToLanFixedCode": null`, …). All of them throw `JsonSyntaxException` and take the same path, matching the regexes this replaces, which simply found no match and left such files alone. `RuntimeException` is caught alongside `IOException` because Gson's parse failures are unchecked;
- an *absent* `openToLanFixedCodeEnabled` still means enabled (the `BaseSafraClientConfig` default), and an empty or unparseable **string** code is still regenerated rather than rejected — that is what `ensureOpenToLanFixedCode()` does on Forge with the `""` the client writes by default;
- the config is replaced atomically: the new JSON is serialized into a sibling temp file and moved onto the target with `ATOMIC_MOVE` (plain `REPLACE_EXISTING` fallback), so a failed or interrupted write cannot truncate an existing config and strand the server on a random code again. Note that `Files.createTempFile` yields `0600`, so a config written by this path no longer follows the umask — happy to carry the old permissions over if you would rather keep `0644`;
- clients are unaffected — `serverStarted` still returns early for the integrated server, so nothing is written when a world is opened to LAN.

### Testing

`./gradlew :fabric:classes` — `BUILD SUCCESSFUL`.

The old and new `loadFixedCode` implementations were run side by side against real config files in a temp dir:

| config on disk | old | new |
| --- | --- | --- |
| missing | `null` on every start | same 16-char code on every start, file created |
| stored valid code | code reused | code reused, file byte-identical |
| no fixed-code keys (older config) | `null` | code generated, `rendezvousUrl` and other keys preserved |
| `"openToLanFixedCodeEnabled": false` | `null` | `null`, file untouched |
| `"openToLanFixedCode": ""` (client default) | `null` | code generated, sibling keys preserved |
| `{ this is not json` | `null` | `null`, no throw |
| `[]`, `null`, `"unexpected"`, `42`, empty file | `null`, file untouched | `null`, file untouched |
| `"openToLanFixedCodeEnabled"` set to `[]`, `null`, `{}` or `"true"` | `null`, file untouched | `null`, file untouched |
| `"openToLanFixedCode"` set to `[]` or `null` | `null`, file untouched | `null`, file untouched |

Plus the write path, with a writer rigged to fail part-way through serialization (Gson surfaces this as `JsonIOException`):

| | direct write | temp file + move |
| --- | --- | --- |
| write fails midway | config left as `{\n  "` — settings lost | config byte-identical, temp file cleaned up |
| write succeeds | complete config | complete config, no temp file left behind |


