### PR TITLE
fix(fabric): return to the server list after a failed or cancelled P2P join

### DIFF
--- a/fabric/src/client/java/org/developerkubilay/safra/mixin/client/MultiplayerScreenMixin.java
+++ b/fabric/src/client/java/org/developerkubilay/safra/mixin/client/MultiplayerScreenMixin.java
@@ -3,9 +3,7 @@ package org.developerkubilay.safra.mixin.client;
 import org.developerkubilay.safra.client.p2p.P2pManager;
 import org.developerkubilay.safra.client.p2p.P2pErrorComponents;
 import org.developerkubilay.safra.client.p2p.P2pConnectingScreen;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -14,17 +12,12 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.DisconnectedScreen;
-import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.network.chat.Component;
 
 @Mixin(JoinMultiplayerScreen.class)
 abstract class MultiplayerScreenMixin {
-    @Shadow
-    @Final
-    private Screen lastScreen;
-
     @Inject(method = "join", at = @At("HEAD"), cancellable = true)
     private void safra$rewriteP2pBeforeVanillaParse(ServerData serverInfo, CallbackInfo ci) {
         if (serverInfo == null || !P2pManager.isP2pConnectionAddress(serverInfo.ip)) {
@@ -33,7 +26,7 @@ abstract class MultiplayerScreenMixin {
 
         JoinMultiplayerScreen self = (JoinMultiplayerScreen) (Object) this;
         P2pConnectingScreen progressScreen = new P2pConnectingScreen(
-            this.lastScreen,
+            self,
             () -> P2pManager.getInstance().cancelPendingRewrite()
         );
         Minecraft.getInstance().setScreenAndShow(progressScreen);
@@ -48,7 +41,7 @@ abstract class MultiplayerScreenMixin {
                         return;
                     }
                     Minecraft.getInstance().setScreenAndShow(new DisconnectedScreen(
-                        this.lastScreen,
+                        self,
                         Component.translatable("connect.failed"),
                         P2pErrorComponents.preparationFailure(cause)
                     ));


### PR DESCRIPTION
### Problem

`MultiplayerScreenMixin` intercepts `JoinMultiplayerScreen#join` for P2P entries and shows its own screens, passing the shadowed `lastScreen` as their parent:

```java
P2pConnectingScreen progressScreen = new P2pConnectingScreen(
    this.lastScreen,
    () -> P2pManager.getInstance().cancelPendingRewrite()
);
...
Minecraft.getInstance().setScreenAndShow(new DisconnectedScreen(
    this.lastScreen,
    Component.translatable("connect.failed"),
    P2pErrorComponents.preparationFailure(cause)
));
```

`lastScreen` is the screen the *server list itself* was opened from — the title screen in practice. So on Fabric:

- pressing **Cancel** (or Esc) on the "Connecting…" screen runs `P2pConnectingScreen#cancel`, which does `setScreen(parent)` and throws the player out to the main menu instead of back to the server list;
- when the rewrite fails, the `DisconnectedScreen` does the same. Its three-argument constructor labels the button `gui.toMenu` — "Back to Server List" — and runs `setScreen(this.parent)`, so the button says server list and goes to the title screen.

Vanilla passes the screen itself:

```java
// JoinMultiplayerScreen
public void join(ServerData data) {
    ConnectScreen.startConnecting(this, this.minecraft, ServerAddress.parseString(data.ip), data, false, null);
}
```

and the Forge/NeoForge copies of this mixin already use `(Screen) (Object) this`. Only Fabric drifted.

### Fix

Pass `self` — the `JoinMultiplayerScreen` the mixin already casts a few lines above — as the parent in both places. The `@Shadow @Final private Screen lastScreen` becomes unused and is removed with its imports.

After this, cancelling or failing a P2P join returns to the server list on all three loaders, matching vanilla and matching what the button says.

### Testing

`./gradlew :fabric:clientClasses` — `BUILD SUCCESSFUL` (`:fabric:compileClientJava` executed).

Vanilla behaviour quoted above was read from the 26.1 sources (`DisconnectedScreen`, `ConnectScreen`, `JoinMultiplayerScreen`), not from memory.
